### PR TITLE
help command & queue command fixes

### DIFF
--- a/SongRequestManagerV2/Bots/RequestBot.cs
+++ b/SongRequestManagerV2/Bots/RequestBot.cs
@@ -66,6 +66,11 @@ namespace SongRequestManagerV2.Bots
         public const string BEATMAPS_AS_CDN_ROOT_URL = "https://as.cdn.beatsaver.com";
         public const string BEATMAPS_NA_CDN_ROOT_URL = "https://na.cdn.beatsaver.com";
 
+        //To Fix %beatsaver% Variable in Help
+        public const string BEATSAVER_HOME = "https://beatsaver.com";
+        
+        
+
         private readonly System.Timers.Timer _timer = new System.Timers.Timer(500);
 
         [Inject]

--- a/SongRequestManagerV2/Bots/RequestBot.cs
+++ b/SongRequestManagerV2/Bots/RequestBot.cs
@@ -1606,6 +1606,7 @@ namespace SongRequestManagerV2.Bots
                 var song = req.SongMetaData;
 
                 var moveRequest = false;
+
                 if (moveId == "") {
                     var terms = new string[] { song["songName"].Value, song["songSubName"].Value, song["songAuthorName"].Value, song["levelAuthorName"].Value, req.SongNode["id"].Value, (RequestManager.RequestSongs.ToArray()[i])._requestor.UserName };
                     if (this.DoesContainTerms(request, ref terms)) {
@@ -1613,7 +1614,7 @@ namespace SongRequestManagerV2.Bots
                     }
                 }
                 else {
-                    if (song["id"].Value == moveId) {
+                    if (req._songID == moveId) {
                         moveRequest = true;
                     }
                 }

--- a/SongRequestManagerV2/Bots/RequestBot.cs
+++ b/SongRequestManagerV2/Bots/RequestBot.cs
@@ -66,6 +66,9 @@ namespace SongRequestManagerV2.Bots
         public const string BEATMAPS_AS_CDN_ROOT_URL = "https://as.cdn.beatsaver.com";
         public const string BEATMAPS_NA_CDN_ROOT_URL = "https://na.cdn.beatsaver.com";
 
+        //To Fix %beatsaver% Variable in Help Commands
+        public const string BEATSAVER_HOME = "https://beatsaver.com";
+
         private readonly System.Timers.Timer _timer = new System.Timers.Timer(500);
 
         [Inject]

--- a/SongRequestManagerV2/Bots/RequestBot.cs
+++ b/SongRequestManagerV2/Bots/RequestBot.cs
@@ -66,11 +66,6 @@ namespace SongRequestManagerV2.Bots
         public const string BEATMAPS_AS_CDN_ROOT_URL = "https://as.cdn.beatsaver.com";
         public const string BEATMAPS_NA_CDN_ROOT_URL = "https://na.cdn.beatsaver.com";
 
-        //To Fix %beatsaver% Variable in Help
-        public const string BEATSAVER_HOME = "https://beatsaver.com";
-        
-        
-
         private readonly System.Timers.Timer _timer = new System.Timers.Timer(500);
 
         [Inject]

--- a/SongRequestManagerV2/Bots/SongRequest.cs
+++ b/SongRequestManagerV2/Bots/SongRequest.cs
@@ -75,6 +75,8 @@ namespace SongRequestManagerV2
             set => this.SetProperty(ref this.authorName_, value);
         }
 
+                
+
         public JSONObject SongNode { get; private set; }
         public JSONObject SongMetaData => this.SongNode["metadata"].AsObject;
 
@@ -89,6 +91,9 @@ namespace SongRequestManagerV2
         private string _hash;
         private string _coverURL;
         private string _downloadURL;
+
+        //Allow song id to be queried
+        public string _songID;
 
         private static readonly ConcurrentDictionary<string, Texture2D> _cachedTextures = new ConcurrentDictionary<string, Texture2D>();
 
@@ -113,6 +118,7 @@ namespace SongRequestManagerV2
             this.Status = status;
             this.RequestTime = requestTime;
             this._requestInfo = requestInfo;
+            this._songID = song["id"];
             var version = this.SongNode["versions"].AsArray.Children.FirstOrDefault(x => x["state"].Value == MapStatus.Published.ToString());
             if (version == null) {
                 this.SongVersion = this.SongNode["versions"].AsArray.Children.OrderBy(x => DateTime.Parse(x["createdAt"].Value)).LastOrDefault().AsObject;

--- a/SongRequestManagerV2/Models/CommandManager.cs
+++ b/SongRequestManagerV2/Models/CommandManager.cs
@@ -71,10 +71,10 @@ namespace SongRequestManagerV2.Models
             this.Aliases.Clear();
 
             #region 初期化ごにょごにょ
-            commands.Add(this._commandFactory.Create().Setup("!bsr", "!request", "!add", "!srm").Action(this.Bot.ProcessSongRequest).Help(FlagParameter.Everyone, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. Try and be a little specific. You can look up songs on %beatsaver%", s_atleast1));
-            commands.Add(this._commandFactory.Create().Setup("!lookup", "!find").AsyncAction(this.LookupSongs).Help(FlagParameter.Mod | FlagParameter.Sub | FlagParameter.VIP, "usage: %alias%<song name> or <song id>, omit <>'s.%|%Get a list of songs from %beatsaver% matching your search criteria.", s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!bsr", "!request", "!add", "!srm").Action(this.Bot.ProcessSongRequest).Help(FlagParameter.Everyone, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. Try and be a little specific. You can look up songs on " + RequestBot.BEATSAVER_HOME, s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!lookup", "!find").AsyncAction(this.LookupSongs).Help(FlagParameter.Mod | FlagParameter.Sub | FlagParameter.VIP, "usage: %alias%<song name> or <song id>, omit <>'s.%|%Get a list of songs from " + RequestBot.BEATSAVER_HOME + " matching your search criteria.", s_atleast1));
 
-            commands.Add(this._commandFactory.Create().Setup("!link").Action(this.Bot.ShowSongLink).Help(FlagParameter.Everyone, "usage: %alias% %|%... Shows song details, and an %beatsaver% link to the current song", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!link").Action(this.Bot.ShowSongLink).Help(FlagParameter.Everyone, "usage: %alias% %|%... Shows song details, and a " + RequestBot.BEATSAVER_HOME + " link to the current song", s_nothing));
 
             commands.Add(this._commandFactory.Create().Setup("!open").Action(this.Bot.OpenQueue).Help(FlagParameter.Mod, "usage: %alias%%|%... Opens the queue allowing song requests.", s_nothing));
             commands.Add(this._commandFactory.Create().Setup("!close").Action(this.Bot.CloseQueue).Help(FlagParameter.Mod, "usage: %alias%%|%... Closes the request queue.", s_nothing));
@@ -86,7 +86,7 @@ namespace SongRequestManagerV2.Models
 
             commands.Add(this._commandFactory.Create().Setup("!modadd").Action(this.Bot.ModAdd).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. This ignores ALL filters including bans.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!mtt").Action(this.Bot.MoveRequestToTop).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Moves a song to the top of the request queue.", s_atleast1));
-            commands.Add(this._commandFactory.Create().Setup("!att").Action(this.Bot.AddToTop).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the top of the request queue. Try and be a little specific. You can look up songs on %beatsaver%", s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!att").Action(this.Bot.AddToTop).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the top of the request queue. Try and be a little specific. You can look up songs on " + RequestBot.BEATSAVER_HOME , s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!last", "!demote", "!later").Action(this.Bot.MoveRequestToBottom).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Moves a song to the bottom of the request queue.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!remove").Action(this.Bot.DequeueSong).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Removes a song from the queue.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!wrongsong", "!wrong", "!oops").Action(this.Bot.WrongSong).Help(FlagParameter.Everyone, "usage: %alias%%|%... Removes your last requested song form the queue. It can be requested again later.", s_nothing));
@@ -122,11 +122,11 @@ namespace SongRequestManagerV2.Models
             commands.Add(this._commandFactory.Create().Setup("!every").Action(this.Bot.Every).Help(FlagParameter.Broadcaster, "usage: every <minutes> %|% Run a command every <minutes>.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!in").Action(this.Bot.EventIn).Help(FlagParameter.Broadcaster, "usage: in <minutes> <bot command>.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!clearevents").Action(this.Bot.ClearEvents).Help(FlagParameter.Broadcaster, "usage: %alias% %|% Clear all timer events."));
-            commands.Add(this._commandFactory.Create().Setup("!addnew", "!addlatest").AsyncAction(this.Bot.AddsongsFromnewest).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the latest maps from %beatsaver%, filtered by the previous selected allowmappers command", s_nothing));
-            commands.Add(this._commandFactory.Create().Setup("!addpp").AsyncAction(this.Bot.AddsongsFromRank).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the rank maps from %beatsaver%, filtered by the previous selected allowmappers command", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!addnew", "!addlatest").AsyncAction(this.Bot.AddsongsFromnewest).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the latest maps from " + RequestBot.BEATSAVER_HOME + " , filtered by the previous selected allowmappers command", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!addpp").AsyncAction(this.Bot.AddsongsFromRank).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the rank maps from " + RequestBot.BEATSAVER_HOME + " , filtered by the previous selected allowmappers command", s_nothing));
             commands.Add(this._commandFactory.Create().Setup("!backup").Action(this.Bot.BackupStreamcore).Help(CmdFlags.Broadcaster, "Backup %SRM% directory.", s_anything));
 
-            commands.Add(this._commandFactory.Create().Setup("!queuestatus").Action(this.Bot.QueueStatus).Help(FlagParameter.Mod, "usage: %alias% %|% Show current queue status", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!queuestatus").Action(this.Bot.QueueStatus).Help(FlagParameter.Everyone, "usage: %alias% %|% Show current queue status", s_nothing));
 
             commands.Add(this._commandFactory.Create().Setup("!QueueLottery").Action(this.Bot.QueueLottery).Help(FlagParameter.Broadcaster, "usage: %alias% <entry count> %|% Shuffle the queue and reduce to <entry count> entries. Close the queue.", s_anything));
 

--- a/SongRequestManagerV2/Models/CommandManager.cs
+++ b/SongRequestManagerV2/Models/CommandManager.cs
@@ -71,10 +71,10 @@ namespace SongRequestManagerV2.Models
             this.Aliases.Clear();
 
             #region 初期化ごにょごにょ
-            commands.Add(this._commandFactory.Create().Setup("!bsr", "!request", "!add", "!srm").Action(this.Bot.ProcessSongRequest).Help(FlagParameter.Everyone, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. Try and be a little specific. You can look up songs on " + RequestBot.BEATSAVER_HOME , s_atleast1));
-            commands.Add(this._commandFactory.Create().Setup("!lookup", "!find").AsyncAction(this.LookupSongs).Help(FlagParameter.Mod | FlagParameter.Sub | FlagParameter.VIP, "usage: %alias%<song name> or <song id>, omit <>'s.%|%Get a list of songs from " + RequestBot.BEATSAVER_HOME + " matching your search criteria.", s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!bsr", "!request", "!add", "!srm").Action(this.Bot.ProcessSongRequest).Help(FlagParameter.Everyone, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. Try and be a little specific. You can look up songs on %beatsaver%", s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!lookup", "!find").AsyncAction(this.LookupSongs).Help(FlagParameter.Mod | FlagParameter.Sub | FlagParameter.VIP, "usage: %alias%<song name> or <song id>, omit <>'s.%|%Get a list of songs from %beatsaver% matching your search criteria.", s_atleast1));
 
-            commands.Add(this._commandFactory.Create().Setup("!link").Action(this.Bot.ShowSongLink).Help(FlagParameter.Everyone, "usage: %alias% %|%... Shows song details, and an " + RequestBot.BEATSAVER_HOME + " link to the current song", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!link").Action(this.Bot.ShowSongLink).Help(FlagParameter.Everyone, "usage: %alias% %|%... Shows song details, and an %beatsaver% link to the current song", s_nothing));
 
             commands.Add(this._commandFactory.Create().Setup("!open").Action(this.Bot.OpenQueue).Help(FlagParameter.Mod, "usage: %alias%%|%... Opens the queue allowing song requests.", s_nothing));
             commands.Add(this._commandFactory.Create().Setup("!close").Action(this.Bot.CloseQueue).Help(FlagParameter.Mod, "usage: %alias%%|%... Closes the request queue.", s_nothing));
@@ -86,7 +86,7 @@ namespace SongRequestManagerV2.Models
 
             commands.Add(this._commandFactory.Create().Setup("!modadd").Action(this.Bot.ModAdd).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. This ignores ALL filters including bans.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!mtt").Action(this.Bot.MoveRequestToTop).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Moves a song to the top of the request queue.", s_atleast1));
-            commands.Add(this._commandFactory.Create().Setup("!att").Action(this.Bot.AddToTop).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the top of the request queue. Try and be a little specific. You can look up songs on " + RequestBot.BEATSAVER_HOME, s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!att").Action(this.Bot.AddToTop).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the top of the request queue. Try and be a little specific. You can look up songs on %beatsaver%", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!last", "!demote", "!later").Action(this.Bot.MoveRequestToBottom).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Moves a song to the bottom of the request queue.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!remove").Action(this.Bot.DequeueSong).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Removes a song from the queue.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!wrongsong", "!wrong", "!oops").Action(this.Bot.WrongSong).Help(FlagParameter.Everyone, "usage: %alias%%|%... Removes your last requested song form the queue. It can be requested again later.", s_nothing));
@@ -122,11 +122,11 @@ namespace SongRequestManagerV2.Models
             commands.Add(this._commandFactory.Create().Setup("!every").Action(this.Bot.Every).Help(FlagParameter.Broadcaster, "usage: every <minutes> %|% Run a command every <minutes>.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!in").Action(this.Bot.EventIn).Help(FlagParameter.Broadcaster, "usage: in <minutes> <bot command>.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!clearevents").Action(this.Bot.ClearEvents).Help(FlagParameter.Broadcaster, "usage: %alias% %|% Clear all timer events."));
-            commands.Add(this._commandFactory.Create().Setup("!addnew", "!addlatest").AsyncAction(this.Bot.AddsongsFromnewest).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the latest maps from " + RequestBot.BEATSAVER_HOME + " , filtered by the previous selected allowmappers command", s_nothing));
-            commands.Add(this._commandFactory.Create().Setup("!addpp").AsyncAction(this.Bot.AddsongsFromRank).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the rank maps from " + RequestBot.BEATSAVER_HOME + " , filtered by the previous selected allowmappers command", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!addnew", "!addlatest").AsyncAction(this.Bot.AddsongsFromnewest).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the latest maps from %beatsaver%, filtered by the previous selected allowmappers command", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!addpp").AsyncAction(this.Bot.AddsongsFromRank).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the rank maps from %beatsaver%, filtered by the previous selected allowmappers command", s_nothing));
             commands.Add(this._commandFactory.Create().Setup("!backup").Action(this.Bot.BackupStreamcore).Help(CmdFlags.Broadcaster, "Backup %SRM% directory.", s_anything));
 
-            commands.Add(this._commandFactory.Create().Setup("!queuestatus").Action(this.Bot.QueueStatus).Help(FlagParameter.Everyone, "usage: %alias% %|% Show current queue status", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!queuestatus").Action(this.Bot.QueueStatus).Help(FlagParameter.Mod, "usage: %alias% %|% Show current queue status", s_nothing));
 
             commands.Add(this._commandFactory.Create().Setup("!QueueLottery").Action(this.Bot.QueueLottery).Help(FlagParameter.Broadcaster, "usage: %alias% <entry count> %|% Shuffle the queue and reduce to <entry count> entries. Close the queue.", s_anything));
 

--- a/SongRequestManagerV2/Models/CommandManager.cs
+++ b/SongRequestManagerV2/Models/CommandManager.cs
@@ -71,10 +71,10 @@ namespace SongRequestManagerV2.Models
             this.Aliases.Clear();
 
             #region 初期化ごにょごにょ
-            commands.Add(this._commandFactory.Create().Setup("!bsr", "!request", "!add", "!srm").Action(this.Bot.ProcessSongRequest).Help(FlagParameter.Everyone, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. Try and be a little specific. You can look up songs on %beatsaver%", s_atleast1));
-            commands.Add(this._commandFactory.Create().Setup("!lookup", "!find").AsyncAction(this.LookupSongs).Help(FlagParameter.Mod | FlagParameter.Sub | FlagParameter.VIP, "usage: %alias%<song name> or <song id>, omit <>'s.%|%Get a list of songs from %beatsaver% matching your search criteria.", s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!bsr", "!request", "!add", "!srm").Action(this.Bot.ProcessSongRequest).Help(FlagParameter.Everyone, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. Try and be a little specific. You can look up songs on " + RequestBot.BEATSAVER_HOME , s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!lookup", "!find").AsyncAction(this.LookupSongs).Help(FlagParameter.Mod | FlagParameter.Sub | FlagParameter.VIP, "usage: %alias%<song name> or <song id>, omit <>'s.%|%Get a list of songs from " + RequestBot.BEATSAVER_HOME + " matching your search criteria.", s_atleast1));
 
-            commands.Add(this._commandFactory.Create().Setup("!link").Action(this.Bot.ShowSongLink).Help(FlagParameter.Everyone, "usage: %alias% %|%... Shows song details, and an %beatsaver% link to the current song", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!link").Action(this.Bot.ShowSongLink).Help(FlagParameter.Everyone, "usage: %alias% %|%... Shows song details, and an " + RequestBot.BEATSAVER_HOME + " link to the current song", s_nothing));
 
             commands.Add(this._commandFactory.Create().Setup("!open").Action(this.Bot.OpenQueue).Help(FlagParameter.Mod, "usage: %alias%%|%... Opens the queue allowing song requests.", s_nothing));
             commands.Add(this._commandFactory.Create().Setup("!close").Action(this.Bot.CloseQueue).Help(FlagParameter.Mod, "usage: %alias%%|%... Closes the request queue.", s_nothing));
@@ -86,7 +86,7 @@ namespace SongRequestManagerV2.Models
 
             commands.Add(this._commandFactory.Create().Setup("!modadd").Action(this.Bot.ModAdd).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the request queue. This ignores ALL filters including bans.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!mtt").Action(this.Bot.MoveRequestToTop).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Moves a song to the top of the request queue.", s_atleast1));
-            commands.Add(this._commandFactory.Create().Setup("!att").Action(this.Bot.AddToTop).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the top of the request queue. Try and be a little specific. You can look up songs on %beatsaver%", s_atleast1));
+            commands.Add(this._commandFactory.Create().Setup("!att").Action(this.Bot.AddToTop).Help(FlagParameter.Mod, "usage: %alias%<songname> or <song id>, omit <,>'s. %|%This adds a song to the top of the request queue. Try and be a little specific. You can look up songs on " + RequestBot.BEATSAVER_HOME, s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!last", "!demote", "!later").Action(this.Bot.MoveRequestToBottom).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Moves a song to the bottom of the request queue.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!remove").Action(this.Bot.DequeueSong).Help(FlagParameter.Mod, "usage: %alias%<songname>,<username>,<song id> %|%... Removes a song from the queue.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!wrongsong", "!wrong", "!oops").Action(this.Bot.WrongSong).Help(FlagParameter.Everyone, "usage: %alias%%|%... Removes your last requested song form the queue. It can be requested again later.", s_nothing));
@@ -122,11 +122,11 @@ namespace SongRequestManagerV2.Models
             commands.Add(this._commandFactory.Create().Setup("!every").Action(this.Bot.Every).Help(FlagParameter.Broadcaster, "usage: every <minutes> %|% Run a command every <minutes>.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!in").Action(this.Bot.EventIn).Help(FlagParameter.Broadcaster, "usage: in <minutes> <bot command>.", s_atleast1));
             commands.Add(this._commandFactory.Create().Setup("!clearevents").Action(this.Bot.ClearEvents).Help(FlagParameter.Broadcaster, "usage: %alias% %|% Clear all timer events."));
-            commands.Add(this._commandFactory.Create().Setup("!addnew", "!addlatest").AsyncAction(this.Bot.AddsongsFromnewest).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the latest maps from %beatsaver%, filtered by the previous selected allowmappers command", s_nothing));
-            commands.Add(this._commandFactory.Create().Setup("!addpp").AsyncAction(this.Bot.AddsongsFromRank).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the rank maps from %beatsaver%, filtered by the previous selected allowmappers command", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!addnew", "!addlatest").AsyncAction(this.Bot.AddsongsFromnewest).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the latest maps from " + RequestBot.BEATSAVER_HOME + " , filtered by the previous selected allowmappers command", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!addpp").AsyncAction(this.Bot.AddsongsFromRank).Help(FlagParameter.Mod, "usage: %alias% <listname>%|%... Adds the rank maps from " + RequestBot.BEATSAVER_HOME + " , filtered by the previous selected allowmappers command", s_nothing));
             commands.Add(this._commandFactory.Create().Setup("!backup").Action(this.Bot.BackupStreamcore).Help(CmdFlags.Broadcaster, "Backup %SRM% directory.", s_anything));
 
-            commands.Add(this._commandFactory.Create().Setup("!queuestatus").Action(this.Bot.QueueStatus).Help(FlagParameter.Mod, "usage: %alias% %|% Show current queue status", s_nothing));
+            commands.Add(this._commandFactory.Create().Setup("!queuestatus").Action(this.Bot.QueueStatus).Help(FlagParameter.Everyone, "usage: %alias% %|% Show current queue status", s_nothing));
 
             commands.Add(this._commandFactory.Create().Setup("!QueueLottery").Action(this.Bot.QueueLottery).Help(FlagParameter.Broadcaster, "usage: %alias% <entry count> %|% Shuffle the queue and reduce to <entry count> entries. Close the queue.", s_anything));
 


### PR DESCRIPTION
Fixes a few help commands ( eg !bsr ? ) only showing %beatsaver% instead of linking to beatsaver.com

Allow the use of !queuestatus command for everyone by default (I don't see any reason why this should be mod only)

Fix using beatsaver IDs in queue commands resulting in an error ( eg !mtt 1f33e )